### PR TITLE
로그인 후 토큰 저장 및 로그인 상태 관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-hook-form": "^7.54.0",
         "react-router": "^7.0.2",
         "recoil": "^0.7.7",
-        "styled-components": "^6.1.13"
+        "styled-components": "^6.1.13",
+        "universal-cookie": "^7.2.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -3183,6 +3184,25 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
+      "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-hook-form": "^7.54.0",
     "react-router": "^7.0.2",
     "recoil": "^0.7.7",
-    "styled-components": "^6.1.13"
+    "styled-components": "^6.1.13",
+    "universal-cookie": "^7.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,9 @@
 import { Outlet } from "react-router";
 import "./App.css";
-import { useRecoilValue } from "recoil";
-import isLoggedInAtom from "./recoil/isLoggedIn/atom";
 
 function App() {
-  const isLoggedIn = useRecoilValue(isLoggedInAtom);
-
   return (
     <>
-      {/* 로그인 확인용으로 간단하게 만들어놨습니다! 머지하기 전에 이 코드는 삭제하고 진행하겠습니다 */}
-      <span>{isLoggedIn ? '로그인 O 👍' : '로그인 X 👎'}</span>
       <Outlet />
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,15 @@
 import { Outlet } from "react-router";
 import "./App.css";
+import { useRecoilValue } from "recoil";
+import isLoggedInAtom from "./recoil/isLoggedIn/atom";
 
 function App() {
+  const isLoggedIn = useRecoilValue(isLoggedInAtom);
+
   return (
     <>
+      {/* 로그인 확인용으로 간단하게 만들어놨습니다! 머지하기 전에 이 코드는 삭제하고 진행하겠습니다 */}
+      <span>{isLoggedIn ? '로그인 O 👍' : '로그인 X 👎'}</span>
       <Outlet />
     </>
   );

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,7 +1,10 @@
 import Axios from "@/apis/@core";
-import { LoginDataType } from "@/types/auth";
+import { LoginDataType, LoginResponse } from "@/types/auth";
 
-export async function login({ email, password }: LoginDataType) {
+export async function login({
+  email,
+  password,
+}: LoginDataType): Promise<LoginResponse> {
   const response = await Axios.post("/api/auth/login", {
     email,
     password,

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,11 +1,14 @@
 import { login } from "@/apis/auth";
 import { ROOT_PATH } from "@/constants/routes";
+import isLoggedInAtom from "@/recoil/isLoggedIn/atom";
 import { setCookie } from "@/utils/cookie";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
+import { useSetRecoilState } from "recoil";
 
 export const useLogin = () => {
   const navigate = useNavigate();
+  const setIsLoggedIn = useSetRecoilState(isLoggedInAtom);
 
   return useMutation({
     mutationFn: login,
@@ -13,6 +16,7 @@ export const useLogin = () => {
       const { accessToken } = data;
 
       setCookie("accessToken", accessToken);
+      setIsLoggedIn(true);
       navigate(ROOT_PATH.ROOT);
     },
     onError: () => {

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,5 +1,6 @@
 import { login } from "@/apis/auth";
 import { ROOT_PATH } from "@/constants/routes";
+import { setCookie } from "@/utils/cookie";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 
@@ -8,7 +9,10 @@ export const useLogin = () => {
 
   return useMutation({
     mutationFn: login,
-    onSuccess: () => {
+    onSuccess: (data) => {
+      const { accessToken } = data;
+
+      setCookie("accessToken", accessToken);
       navigate(ROOT_PATH.ROOT);
     },
     onError: () => {

--- a/src/recoil/isLoggedIn/atom.ts
+++ b/src/recoil/isLoggedIn/atom.ts
@@ -1,0 +1,9 @@
+import { getCookie } from "@/utils/cookie";
+import { atom } from "recoil";
+
+const isLoggedInAtom = atom<boolean>({
+  key: "isLoggedIn",
+  default: !!getCookie("accessToken"),
+});
+
+export default isLoggedInAtom;

--- a/src/recoil/isLoggedIn/index.ts
+++ b/src/recoil/isLoggedIn/index.ts
@@ -1,0 +1,3 @@
+import isLoggedInAtom from "./atom";
+
+export default isLoggedInAtom;

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -2,3 +2,8 @@ export type LoginDataType = {
   email: string;
   password: string;
 };
+
+export type LoginResponse = {
+  memberId: number;
+  accessToken: string;
+};

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,23 @@
+import Cookies, {
+  Cookie,
+  CookieGetOptions,
+  CookieSetOptions,
+} from "universal-cookie";
+
+const cookies = new Cookies();
+
+export const setCookie = (
+  name: string,
+  value: Cookie,
+  options?: CookieSetOptions
+) => {
+  cookies.set(name, value, { ...options });
+};
+
+export const getCookie = (name: string, options?: CookieGetOptions) => {
+  return cookies.get(name, { ...options });
+};
+
+export const removeCookie = (name: string, options?: CookieSetOptions) => {
+  cookies.remove(name, { ...options });
+};


### PR DESCRIPTION
## ⭐ Key Changes

- 로그인 성공 후 `accessToken`을 쿠키에 저장했습니다. (`universal-cookie` 라이브러리 사용)
- 로그인 상태를 관리하는 전역 상태 `isLoggedIn`을 생성했습니다.

## 🖐️To reviewers

- `universal-cookie`라이브러리를 선택한 이유는 `js-cookie` 에 비해 최근까지 업데이트 되었고, SSR도 지원한다고해서 확장성 측면에서 더 좋지 않을까 싶어서 선택했습니다!

- 로그인 전역 상태를 `atom`을 만들어서 `boolean` 값으로 관리했습니다.
  - 폴더 구조는 나중에 `atom`이 많아졌을 때 `import` 문의 간결해지고, `atom`과 `selector`의 이름이 더 명확해지는 것 같아 다음 링크를 참고해 구현했습니다. ([Recoil Project Structure Best Practices](https://parkjju.github.io/vue-TIL/daily/220703-recoil.html))

- `recoil` `key` 값은 재사용이 되는 경우를 못봤어서 일단 상수화하진 않았는데 하는것도 괜찮아보여서 피드백 주시면 진행하겠습니다!!

- `App.tsx`에 있는 코드는 리뷰 이후 삭제하겠습니다.

## 📌issue

close #18 
