### PR TITLE
로그인 에러 처리

### DIFF
--- a/src/constants/message/index.ts
+++ b/src/constants/message/index.ts
@@ -2,7 +2,7 @@
 export const AUTH_ERROR_MSG = {
   EMAIL_REQUIRED: "이메일을 입력해주세요.",
   EMAIL_PATTERN: "이메일 형식이 아닙니다.",
-  EMAIL_NOT_EXIST: "존재하지 않는 이메일입니다.",
   PASSWORD_REQUIRED: "비밀번호를 입력해주세요.",
-  PASSWORD_INCORRECT: "비밀번호가 일치하지 않습니다.",
+  INCORRECT_EMAIL_OR_PASSWORD:
+    "아이디 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요.",
 };

--- a/src/constants/message/index.ts
+++ b/src/constants/message/index.ts
@@ -1,0 +1,8 @@
+// 인증 관련 에러 메세지
+export const AUTH_ERROR_MSG = {
+  EMAIL_REQUIRED: "이메일을 입력해주세요.",
+  EMAIL_PATTERN: "이메일 형식이 아닙니다.",
+  EMAIL_NOT_EXIST: "존재하지 않는 이메일입니다.",
+  PASSWORD_REQUIRED: "비밀번호를 입력해주세요.",
+  PASSWORD_INCORRECT: "비밀번호가 일치하지 않습니다.",
+};

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,5 +1,4 @@
 import { login } from "@/apis/auth";
-import { AUTH_ERROR_MSG } from "@/constants/message";
 import { ROOT_PATH } from "@/constants/routes";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
@@ -7,7 +6,7 @@ import { useNavigate } from "react-router";
 
 interface UseLoginParams {
   /** 로그인 중 발생한 에러처리를 위한 함수 */
-  loginErrorHandler: (name: "email" | "password", message: string) => void;
+  loginErrorHandler: () => void;
 }
 
 export const useLogin = ({ loginErrorHandler }: UseLoginParams) => {
@@ -22,10 +21,8 @@ export const useLogin = ({ loginErrorHandler }: UseLoginParams) => {
       if (axios.isAxiosError(err)) {
         const { status } = err;
 
-        if (status === 401) {
-          loginErrorHandler("password", AUTH_ERROR_MSG.PASSWORD_INCORRECT);
-        } else if (status === 404) {
-          loginErrorHandler("email", AUTH_ERROR_MSG.EMAIL_NOT_EXIST);
+        if (status === 401 || status === 404) {
+          loginErrorHandler();
         }
       }
     },

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,9 +1,16 @@
 import { login } from "@/apis/auth";
+import { AUTH_ERROR_MSG } from "@/constants/message";
 import { ROOT_PATH } from "@/constants/routes";
 import { useMutation } from "@tanstack/react-query";
+import axios from "axios";
 import { useNavigate } from "react-router";
 
-export const useLogin = () => {
+interface UseLoginParams {
+  /** 로그인 중 발생한 에러처리를 위한 함수 */
+  loginErrorHandler: (name: "email" | "password", message: string) => void;
+}
+
+export const useLogin = ({ loginErrorHandler }: UseLoginParams) => {
   const navigate = useNavigate();
 
   return useMutation({
@@ -11,8 +18,16 @@ export const useLogin = () => {
     onSuccess: () => {
       navigate(ROOT_PATH.ROOT);
     },
-    onError: () => {
-      // 에러처리
+    onError: (err) => {
+      if (axios.isAxiosError(err)) {
+        const { status } = err;
+
+        if (status === 401) {
+          loginErrorHandler("password", AUTH_ERROR_MSG.PASSWORD_INCORRECT);
+        } else if (status === 404) {
+          loginErrorHandler("email", AUTH_ERROR_MSG.EMAIL_NOT_EXIST);
+        }
+      }
     },
   });
 };

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -13,8 +13,12 @@ const LoginPage = () => {
   } = useForm<LoginDataType>();
 
   const { mutate } = useLogin({
-    loginErrorHandler: (name, message) => {
-      setError(name, { message }, { shouldFocus: true });
+    loginErrorHandler: () => {
+      setError(
+        "password",
+        { message: AUTH_ERROR_MSG.INCORRECT_EMAIL_OR_PASSWORD },
+        { shouldFocus: true }
+      );
     },
   });
   const onSubmit: SubmitHandler<LoginDataType> = (data) => {

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -2,15 +2,21 @@ import { LoginDataType } from "@/types/auth";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { AUTH_PATTERN } from "@/constants/pattern";
 import { useLogin } from "@/hooks/auth";
+import { AUTH_ERROR_MSG } from "@/constants/message";
 
 const LoginPage = () => {
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<LoginDataType>();
-  const { mutate } = useLogin();
 
+  const { mutate } = useLogin({
+    loginErrorHandler: (name, message) => {
+      setError(name, { message }, { shouldFocus: true });
+    },
+  });
   const onSubmit: SubmitHandler<LoginDataType> = (data) => {
     mutate(data);
   };
@@ -21,10 +27,10 @@ const LoginPage = () => {
           type="email"
           placeholder="이메일"
           {...register("email", {
-            required: "이메일을 입력해주세요.",
+            required: AUTH_ERROR_MSG.EMAIL_REQUIRED,
             pattern: {
               value: AUTH_PATTERN.EMAIL,
-              message: "이메일 형식이 아닙니다.",
+              message: AUTH_ERROR_MSG.EMAIL_PATTERN,
             },
           })}
         />
@@ -33,9 +39,10 @@ const LoginPage = () => {
           type="password"
           placeholder="비밀번호"
           {...register("password", {
-            required: "비밀번호를 입력해주세요.",
+            required: AUTH_ERROR_MSG.PASSWORD_REQUIRED,
           })}
         />
+        {errors.password && <span>{errors.password.message}</span>}
         <button type="submit">제출</button>
       </form>
     </main>


### PR DESCRIPTION
## ⭐ Key Changes

- 존재하지 않는 이메일, 비밀번호가 틀린 경우에 대한 에러 처리를 진행했습니다.
- 인증 관련 에러 메세지를 상수화했습니다.(`AUTH_ERROR_MSG`)

## 🖐️To reviewers

### 에러 처리

현재 로그인 API 명세서에 나타나있는 `401(비밀번호 틀린 경우)`, `404(가입되지 않은 이메일인 경우)`에러에 대한 에러를 처리했습니다.
500대 공통 에러에 대한 처리는 해당 PR과는 맞지 않는 것 같아 진행하지 않았습니다.

에러 처리를 어떻게 할지 고민하다가 이렇게 처리하면 어떨까 싶어서 정리해봤습니다. 아직 경험이 부족해서 좋은 방법인지 모르겠으니 피드백 부탁드립니다! 우선 저는 여기에 맞게 로그인에 대한 에러 처리는 `useMutation`의 `onError`를 통해 진행했습니다.
<img width="670" alt="스크린샷 2024-12-13 오후 5 00 38" src="https://github.com/user-attachments/assets/d8ba8698-e409-4d89-a5aa-f82c110839ac" />

### 네이밍 관련

`loginErrorHandler`, `UseLoginParams`이 두 변수?의 네이밍이 잘 생각나지 않았는데.. 피드백 부탁드립니다.
- `UseLoginParams`: `useLogin` 훅의 매개변수라 기능 그대로 지어봤습니다.
- `loginErrorHandler`: `useLogin`을 사용할 때 어떤 값을 매개변수로 넘겨주는지 직관적으로 알기 쉽게 객체 형태로 받았고, `로그인 중 발생한 에러처리를 위한 함수`이기 때문에 핸들러라고 네이밍 해봤습니다!!

## 📌issue

close #16 
