### PR TITLE
로그인, 비밀번호 변경 페이지의 폰트를 수정했습니다.

### DIFF
--- a/src/components/@common/Button/PrimaryButton/PrimaryButton.styled.ts
+++ b/src/components/@common/Button/PrimaryButton/PrimaryButton.styled.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
 export const Button = styled.button<{ $width?: string }>`
-  ${({ theme }) => theme.typo.B1_R};
-  padding: 16px;
+  ${({ theme }) => theme.typo.B1_B};
+  padding: 13.5px 16px;
   width: ${({ $width }) => $width || '320px'};
   color: ${({ theme }) => theme.colors.White};
   background-color: ${({ theme }) => theme.colors.Blue_500};
@@ -10,6 +10,7 @@ export const Button = styled.button<{ $width?: string }>`
   transition: color 0.3s ease;
 
   &:disabled {
+    ${({ theme }) => theme.typo.B1_R};
     color: ${({ theme }) => theme.colors.Gray_800};
     background-color: ${({ theme }) => theme.colors.Gray_200};
     pointer-events: none;

--- a/src/components/auth/Form/EmailVerificationForm/EmailVerificationForm.styled.ts
+++ b/src/components/auth/Form/EmailVerificationForm/EmailVerificationForm.styled.ts
@@ -7,7 +7,7 @@ export const SendCodeContent = styled.div`
 
 export const SendCodeBtn = styled(SecondaryButton)`
   position: absolute;
-  top: 47px;
+  top: 46px;
   right: 0;
 `;
 
@@ -20,6 +20,6 @@ export const Time = styled.div<{
   $text?: string;
 }>`
   position: absolute;
-  top: 18px;
+  top: 16.5px;
   right: ${({ $text }) => ($text ? '36px' : '16px')};
 `;

--- a/src/components/auth/InputField/InputField.styled.ts
+++ b/src/components/auth/InputField/InputField.styled.ts
@@ -40,7 +40,7 @@ export const Input = styled.input<{
   $text?: string;
 }>`
   ${({ theme }) => theme.typo.B1_R};
-  padding: ${({ $text }) => ($text ? '16px 36px 16px 16px' : '16px')};
+  padding: ${({ $text }) => ($text ? '15px 36px 15px 16px' : '15px 16px')};
   width: 100%;
   color: ${({ theme }) => theme.colors.Gray_1000};
   border: 1px solid
@@ -63,7 +63,7 @@ export const Input = styled.input<{
 
 export const CancelBtn = styled.button`
   position: absolute;
-  top: 18px;
+  top: 16.5px;
   right: 16px;
   padding: 0;
   width: 20px;

--- a/src/pages/auth/login/LoginPage.styled.ts
+++ b/src/pages/auth/login/LoginPage.styled.ts
@@ -6,18 +6,14 @@ export const Main = styled.main`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-top: 64px;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 120px auto;
   width: 440px;
 `;
 
 export const LoginHeader = styled.h1`
-  ${({ theme }) => theme.typo.T1_B}
+  ${({ theme }) => theme.typo.D1_B}
   margin-bottom: 64px;
   color: ${({ theme }) => theme.colors.Gray_1000};
-  font-size: 30px;
-  line-height: 38px;
 `;
 
 export const LoginOptions = styled.ul`
@@ -31,7 +27,6 @@ export const LoginOption = styled(Link)`
   ${({ theme }) => theme.typo.B1_R};
   position: relative;
   color: ${({ theme }) => theme.colors.Gray_800};
-  line-height: 20px;
 
   &::after {
     content: '';

--- a/src/pages/auth/resetPassword/ResetPasswordPage.styled.ts
+++ b/src/pages/auth/resetPassword/ResetPasswordPage.styled.ts
@@ -5,17 +5,12 @@ export const Main = styled.main`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-top: 64px;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 120px auto;
   width: 440px;
 `;
 
 export const Header = styled.h1`
   ${({ theme }) => theme.typo.D1_B}
   margin-bottom: 64px;
-  font-size: 30px;
-  font-weight: 600;
-  line-height: 38px;
   color: ${({ theme }) => theme.colors.Gray_1000};
 `;


### PR DESCRIPTION
## ⭐ Key Changes

- 로그인, 비밀번호 변경 페이지에서 잘못 지정한 폰트를 수정했습니다.
- 로그인, 비밀번호 변경 페이지의 위, 아래 `margin`을 120px로 수정했습니다.
- `<InputField>`의 높이를 53px로 수정했습니다.

## 🖐️To reviewers

혹시 디자인 수정이 더 필요한 부분이 보이시면 말씀해주세요!!

## 📌issue

close #57 
