### PR TITLE
토큰 재발급 무한 루프 버그 해결

### DIFF
--- a/src/components/auth/AuthInterceptor/index.tsx
+++ b/src/components/auth/AuthInterceptor/index.tsx
@@ -1,9 +1,13 @@
 import AuthAxios from '@/apis/@core/authInstance';
+import { AUTH_ERROR_MSG } from '@/constants/message';
+import { AUTH_PATH } from '@/constants/routes';
 import { useRefresh } from '@/hooks/auth/useRefresh';
 import accessTokenAtom from '@/recoil/auth/accessToken';
 import axios from 'axios';
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
+
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 interface IAuthInterceptorProps {
   children: React.ReactNode;
@@ -15,11 +19,12 @@ interface IAuthInterceptorProps {
  *      1) AuthInstance의 interceptor 설정
  *  @주요기능
  *      1) API 요청 헤더에 토큰 추가
- *      2) 401에러가 뜨는 경우 refresh 요청
+ *      2) 401에러가 뜨는 경우 토큰 재발급(refresh) 요청
+ *      3) 토큰 재발급 실패 시 로그인 페이지로 이동
  */
 const AuthInterceptor = ({ children }: IAuthInterceptorProps) => {
   const accessToken = useRecoilValue(accessTokenAtom);
-  const { mutateAsync } = useRefresh();
+  const { mutateAsync: refresh } = useRefresh();
 
   const requestInterceptor = AuthAxios.interceptors.request.use((config) => {
     if (accessToken) {
@@ -34,18 +39,23 @@ const AuthInterceptor = ({ children }: IAuthInterceptorProps) => {
     async (err) => {
       const {
         config,
-        response: { status },
+        response: { status, data },
       } = err;
 
       // 권한이 필요한 api 요청에서 access token 에러가 발생하는 경우
       if (status === 401) {
+        if (data?.code === -11002) {
+          return Promise.reject(err);
+        }
+
         try {
-          const { accessToken } = await mutateAsync();
+          const { accessToken } = await refresh();
           config.headers.Authorization = `Bearer ${accessToken}`;
 
           return axios(config);
         } catch (err) {
-          return Promise.reject(err);
+          alert(AUTH_ERROR_MSG.SESSION_EXPIRED);
+          window.location.href = `${BASE_URL}${AUTH_PATH.LOGIN}`;
         }
       }
 

--- a/src/components/auth/TokenRefresher/index.tsx
+++ b/src/components/auth/TokenRefresher/index.tsx
@@ -1,7 +1,10 @@
+import { AUTH_PATH } from '@/constants/routes';
 import { useRefresh } from '@/hooks/auth/useRefresh';
 import accessTokenAtom from '@/recoil/auth/accessToken';
 import isLoggedInAtom from '@/recoil/auth/isLoggedIn';
+import axios from 'axios';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
 import { useRecoilValue } from 'recoil';
 
 interface ITokenRefresherProps {
@@ -15,8 +18,11 @@ interface ITokenRefresherProps {
  *  @주요기능
  *      1) 서비스 접근 시 토큰 재발급
  *      2) 토큰 재발급(refresh) 요청 동안 로딩 처리
+ *      3) 토큰 재발급 실패 시 로그인 페이지로 이동
  */
 const TokenRefresher = ({ children }: ITokenRefresherProps) => {
+  const navigate = useNavigate();
+
   const isLoggedIn = useRecoilValue(isLoggedInAtom);
   const accessToken = useRecoilValue(accessTokenAtom);
   const [isLoading, setIsLoading] = useState(isLoggedIn && !accessToken);
@@ -27,9 +33,13 @@ const TokenRefresher = ({ children }: ITokenRefresherProps) => {
 
     const refresh = async () => {
       try {
-        // refresh api 요청
         await mutateAsync();
       } catch (err) {
+        if (axios.isAxiosError(err)) {
+          if (err.response?.status === 401) {
+            navigate(AUTH_PATH.LOGIN);
+          }
+        }
         console.log('Refresh Result:', err);
       } finally {
         setIsLoading(false);

--- a/src/components/auth/TokenRefresher/index.tsx
+++ b/src/components/auth/TokenRefresher/index.tsx
@@ -47,7 +47,7 @@ const TokenRefresher = ({ children }: ITokenRefresherProps) => {
     };
 
     refresh();
-  }, [isLoading, setIsLoading, mutateAsync]);
+  }, [isLoading, setIsLoading, mutateAsync, navigate]);
 
   if (isLoading) {
     return <div>Loading...😂</div>;

--- a/src/constants/message/index.ts
+++ b/src/constants/message/index.ts
@@ -1,17 +1,29 @@
 // 인증 관련 에러 메세지
 export const AUTH_ERROR_MSG = Object.freeze({
+  // 이메일
   EMAIL_REQUIRED: '이메일을 입력해주세요.',
   EMAIL_PATTERN: '이메일 형식이 아닙니다.',
+
+  // 패스워드
   PASSWORD_REQUIRED: '비밀번호를 입력해주세요.',
-  INCORRECT_EMAIL_OR_PASSWORD:
-    '아이디 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요.',
-  CERTNO_REQUIRED: '인증코드를 입력해주세요.',
-  CERTNO_PATTERN: '인증코드가 일치하지 않습니다.',
   PASSWORD_PATTERN:
     '비밀번호는 공백을 제외하고 알파벳 소문자, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다.',
   PASSWORD_PATTERN_MORE: '비밀번호는 8자 이상 입력해야 합니다.',
   PASSWORD_PATTERN_BELOW: '비밀번호는 20자 이하로 입력해야 합니다.',
   PASSWORD_NOT_MATCH: '비밀번호가 일치하지 않습니다.',
+  INCORRECT_EMAIL_OR_PASSWORD:
+    '아이디 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요.',
+
+  // 인증코드
+  CERTNO_REQUIRED: '인증코드를 입력해주세요.',
+  CERTNO_PATTERN: '인증코드가 일치하지 않습니다.',
+
+  // 닉네임
   NICKNAME_REQUIRED: '닉네임을 입력해주세요.',
-  NICKNAME_PATTERN: '2~20자의 한글, 영문, 숫자만 사용 가능합니다.',
+
+  // 성별
+  GENDER_REQUIRED: '성별을 선택해주세요.',
+
+  // 세션 만료
+  SESSION_EXPIRED: '세션이 만료되었습니다. 다시 로그인해 주세요.',
 });

--- a/src/constants/message/index.ts
+++ b/src/constants/message/index.ts
@@ -20,6 +20,7 @@ export const AUTH_ERROR_MSG = Object.freeze({
 
   // 닉네임
   NICKNAME_REQUIRED: '닉네임을 입력해주세요.',
+  NICKNAME_PATTERN: '2~20자의 한글, 영문, 숫자만 사용 가능합니다.',
 
   // 성별
   GENDER_REQUIRED: '성별을 선택해주세요.',

--- a/src/hooks/auth/useRefresh.ts
+++ b/src/hooks/auth/useRefresh.ts
@@ -1,15 +1,10 @@
 import { refresh } from '@/apis/auth';
-import { AUTH_PATH } from '@/constants/routes';
 import accessTokenAtom from '@/recoil/auth/accessToken';
 import { useMutation } from '@tanstack/react-query';
-import axios from 'axios';
 import { useCookies } from 'react-cookie';
-import { useNavigate } from 'react-router';
 import { useSetRecoilState } from 'recoil';
 
 export const useRefresh = () => {
-  const navigate = useNavigate();
-
   const [, setCookie] = useCookies(['isLoggedIn']);
   const setAccessToken = useSetRecoilState(accessTokenAtom);
 
@@ -22,17 +17,6 @@ export const useRefresh = () => {
       setCookie('isLoggedIn', true, {
         expires,
       });
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err)) {
-        const { status } = err;
-
-        // 리프레시 요청에서도 에러가 발생하는 경우는 로그인 페이지로 이동
-        if (status === 400 || status === 401) {
-          alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
-          navigate(AUTH_PATH.LOGIN);
-        }
-      }
     },
   });
 };


### PR DESCRIPTION
## ⭐ Key Changes

- 비로그인 상태로 권한이 필요한 API 요청 시 토큰 재발급(`refresh`) 요청을 보내면서 발생하는 무한 루프 문제를 해결했습니다.

- `useRefresh`의 `onError` 콜백으로 에러를 처리하지 않고 각각 상황에 맞게 처리하도록 변경했습니다.
  - `AT`와 `RT`의 에러가 `401`로 동일하여 `code`를 사용해서 구분했고, 에러가 `refresh` 요청에서 발생했다면(`code === -11002`) 에러를 반환하여 `catch`문에서 에러를 캐치하여 로그인 페이지로 이동할 수 있게 구현했습니다.

- 환경변수가 추가되어 노션 `환경 변수 값`을 업데이트했습니다. 적용부탁드립니다.

## 🖐️To reviewers

채팅방 리스트 웹소켓 연결하다가 에러를 발견해서 급하게 수정했습니다..!

## 📌issue

close #73 
