### PR TITLE
ESLint 설정 파일 수정

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,8 +25,13 @@ export default tseslint.config(
       ],
       'padding-line-between-statements': [
         'error',
-        { blankLine: 'always', prev: '*', next: 'return' }, // return문 앞에 한 줄 공백 추가
-        { blankLine: 'always', prev: 'export', next: 'export' }, // export 사이에 공백 추가
+        // export 사이에 공백 추가
+        { blankLine: 'always', prev: 'export', next: 'export' },
+        // 변수 선언 사이에 공백 추가
+        { blankLine: 'always', prev: 'const', next: 'const' },
+        { blankLine: 'always', prev: 'let', next: 'let' },
+        // return문 앞에 한 줄 공백 추가
+        { blankLine: 'always', prev: '*', next: 'return' },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,34 +1,33 @@
-import js from "@eslint/js";
-import globals from "globals";
-import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
-import tseslint from "typescript-eslint";
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ['dist'] },
   {
-    extends: [
-      js.configs.recommended,
-      ...tseslint.configs.recommended,
-      "prettier",
-    ],
-    files: ["**/*.{ts,tsx}"],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
-      "react-hooks": reactHooks,
-      "react-refresh": reactRefresh,
-      prettier: require("eslint-plugin-prettier"),
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": [
-        "warn",
+      'react-refresh/only-export-components': [
+        'warn',
         { allowConstantExport: true },
       ],
-      "prettier/prettier": "warn",
+      'padding-line-between-statements': [
+        'error',
+        { blankLine: 'always', prev: '*', next: 'return' }, // return문 앞에 한 줄 공백 추가
+        { blankLine: 'always', prev: 'export', next: 'export' }, // export 사이에 공백 추가
+      ],
     },
   },
 );


### PR DESCRIPTION
## ⭐ Key Changes
- **Prettier 플러그인 제거**: 프로젝트 세팅 시 Prettier 플러그인이 `require`로 등록되어 있어, ESLint가 제대로 적용되지 않던 문제를 해결했습니다.
- **ESLint 규칙 수정**:
  - 변수 선언 사이에 한 줄 공백을 추가하는 규칙 추가
  - `return`문과 `export`문 앞에 한 줄 공백을 추가하는 규칙 추가
## 🖐️To reviewers
- [일전에 lint에 규칙 추가](https://github.com/Friends77/FRI-FRONT/pull/66#discussion_r1909620798) 하기로 논의 되었던 부분 반영했습니다.
- 프로젝트 세팅 시, Prettier 플러그인이 `require`로 등록되어 있어서 프로젝트 전반에 ESLint 적용이 안 되었더라구요.. 😢
검색해본 결과, [ESLint랑 해당 플러그인은 함께 사용하지않는 것이 좋다](https://prettier.io/docs/integrating-with-linters.html#notes)고 하여 Prettier 플러그인을 삭제하였습니다.

## 📌issue

close #88 
