### PR TITLE
refactor: useTransition 훅 적용

### DIFF
--- a/src/components/chat/ChatInvitationDialog/ChatInvitationDialog.styled.ts
+++ b/src/components/chat/ChatInvitationDialog/ChatInvitationDialog.styled.ts
@@ -18,6 +18,18 @@ export const SearchInput = styled(SideBarSearchInput)`
   padding: 0 24px;
 `;
 
+export const LoadingMessage = styled.p`
+  ${({ theme }) => theme.typo.B1_R};
+  color: ${({ theme }) => theme.colors.Gray_700};
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  height: 320px;
+  gap: 4px;
+  padding-bottom: 48px;
+`;
+
 export const EmptyFriendList = styled.div`
   ${({ theme }) => theme.typo.B1_R};
   color: ${({ theme }) => theme.colors.Gray_700};

--- a/src/components/chat/ChatInvitationDialog/index.tsx
+++ b/src/components/chat/ChatInvitationDialog/index.tsx
@@ -4,7 +4,7 @@ import ArrowForward from '@/components/@common/SVG/Icon/ArrowForward';
 import useGetFriendsToInvite from '@/hooks/chat/useGetFriendsToInvite';
 import useSendChatInvite from '@/hooks/chat/useSendChatInvite';
 import { FriendsInvitationStatus, IMemberWithStatus } from '@/types/chat';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router';
 
@@ -24,9 +24,13 @@ const ChatInvitationDialog = ({ title, onClose }: IChatInvitationDialog) => {
 
   const { watch } = methods;
 
+  const keyword = watch('keyword');
+
+  const [isPending, startTransition] = useTransition();
+
   const { data: membersToInvite } = useGetFriendsToInvite({
     roomId,
-    nickname: watch('keyword'),
+    nickname: keyword,
   });
 
   const { mutate: sendChatInvitation } = useSendChatInvite({
@@ -47,53 +51,29 @@ const ChatInvitationDialog = ({ title, onClose }: IChatInvitationDialog) => {
 
   useEffect(() => {
     if (membersToInvite) {
-      const membersWithStatus = membersToInvite.content.map((member) => ({
-        ...member,
-        status: FriendsInvitationStatus.AVAILABLE,
-      }));
+      startTransition(() => {
+        const membersWithStatus = membersToInvite.content.map((member) => ({
+          ...member,
+          status: FriendsInvitationStatus.AVAILABLE,
+        }));
 
-      setMemberList(membersWithStatus);
+        setMemberList(membersWithStatus);
+      });
     }
   }, [membersToInvite]);
+
+  const isNoResults = memberList.length === 0 && keyword && !isPending;
+
+  const isNoFriends = !keyword && memberList.length === 0 && !isPending;
 
   return (
     <CustomModal title={title} onClose={onClose}>
       <FormProvider {...methods}>
         <Styled.InvitationDialog>
           <Styled.SearchInput placeholder="친구 이름 검색" />
-          {memberList.length > 0 ? (
-            <Styled.FriendList>
-              {memberList.map((member) => (
-                <Styled.FriendItem key={member.memberId}>
-                  <Styled.Profile>
-                    <Styled.Image
-                      size={56}
-                      src={member.imageUrl}
-                      alt={member.nickname}
-                    />
-                    <Styled.InfoContent>
-                      <Styled.Nickname>{member.nickname}</Styled.Nickname>
-                      {member.selfDescription && (
-                        <Styled.Description>
-                          {member.selfDescription}
-                        </Styled.Description>
-                      )}
-                    </Styled.InfoContent>
-                  </Styled.Profile>
-                  <Styled.InvitationButton
-                    type="button"
-                    disabled={member.status === FriendsInvitationStatus.INVITED}
-                    $status={member.status}
-                    onClick={() => handleSendChatInvitation(member.memberId)}
-                  >
-                    {member.status === FriendsInvitationStatus.AVAILABLE
-                      ? '초대하기'
-                      : '전송됨'}
-                  </Styled.InvitationButton>
-                </Styled.FriendItem>
-              ))}
-            </Styled.FriendList>
-          ) : (
+          {isNoResults ? (
+            <Styled.EmptyFriendList>검색 결과가 없어요</Styled.EmptyFriendList>
+          ) : isNoFriends ? (
             <Styled.EmptyFriendList>
               아직 등록된 친구가 없어요
               <Styled.FindFriendButton to="/">
@@ -101,6 +81,50 @@ const ChatInvitationDialog = ({ title, onClose }: IChatInvitationDialog) => {
                 <ArrowForward title="친구 찾기" width="24" height="24" />
               </Styled.FindFriendButton>
             </Styled.EmptyFriendList>
+          ) : (
+            <>
+              {isPending ? (
+                <Styled.LoadingMessage>검색 중...</Styled.LoadingMessage>
+              ) : (
+                <>
+                  <Styled.FriendList>
+                    {memberList.map((member) => (
+                      <Styled.FriendItem key={member.memberId}>
+                        <Styled.Profile>
+                          <Styled.Image
+                            size={56}
+                            src={member.imageUrl}
+                            alt={member.nickname}
+                          />
+                          <Styled.InfoContent>
+                            <Styled.Nickname>{member.nickname}</Styled.Nickname>
+                            {member.selfDescription && (
+                              <Styled.Description>
+                                {member.selfDescription}
+                              </Styled.Description>
+                            )}
+                          </Styled.InfoContent>
+                        </Styled.Profile>
+                        <Styled.InvitationButton
+                          type="button"
+                          disabled={
+                            member.status === FriendsInvitationStatus.INVITED
+                          }
+                          $status={member.status}
+                          onClick={() =>
+                            handleSendChatInvitation(member.memberId)
+                          }
+                        >
+                          {member.status === FriendsInvitationStatus.AVAILABLE
+                            ? '초대하기'
+                            : '전송됨'}
+                        </Styled.InvitationButton>
+                      </Styled.FriendItem>
+                    ))}
+                  </Styled.FriendList>
+                </>
+              )}
+            </>
           )}
         </Styled.InvitationDialog>
       </FormProvider>


### PR DESCRIPTION
## ⭐ Key Changes

UI에서 비동기적이고 시간이 오래 걸리는 작업을 처리할 때 UI가 멈추지 않고 부드럽게 업데이트 되도록 useTransition훅을 사용했습니다. 사용한 곳은 아래와 같습니다.
(useTransition 훅을 사용하면 데이터 fetching이나 복잡한 상태 변경이 있을 때, React가 UI를 우선적으로 업데이트하고 시간이 오래 걸리는 작업은 백그라운드에서 처리하도록 만들어줍니다.)

채팅방 초대 다이얼로그(친구 검색)
사이드 바 친구, 채팅방 검색은 프론트에서 검색을 진행하기 때문에 동기적으로 작동하여 렌더링을 지연시키지 않을 것으로 판단, useTransition 훅을 사용하지 않았습니다.

## 📌issue

close #138 
